### PR TITLE
v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- v2.1.1:
+  - date: 2026-04-03
+  - changes:
+    - Remove "lodash" dependency ([84ce097984](https://github.com/gruntjs/grunt-legacy-log-utils/commit/84ce097984), [grunt-legacy-log#35](https://github.com/gruntjs/grunt-legacy-log/issues/35))
 - v2.1.0:
   - date: 2020-07-27
   - changes:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-legacy-log-utils",
   "description": "Static methods for the Grunt 0.4.x logger.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "\"Cowboy\" Ben Alman (http://benalman.com/)",
   "homepage": "http://gruntjs.com/",
   "repository": {


### PR DESCRIPTION
Motivated by https://github.com/gruntjs/grunt-legacy-log/issues/35. I'll submit a PR there shortly that updates lodash (not planning to remove it there) but because `grunt-legacy-log` depends on `grunt-legacy-log-utils` we need to update (or remove) it here first.

@vladikoff Can you publish this to npm and/or add me to the package?