### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "http://gruntjs.com/",
   "repository": {
     "type": "git",
-    "url": "git://github.com/gruntjs/grunt-legacy-log-utils.git"
+    "url": "git+https://github.com/gruntjs/grunt-legacy-log-utils.git"
   },
   "bugs": {
     "url": "http://github.com/gruntjs/grunt-legacy-log-utils/issues"


### PR DESCRIPTION
Updates the package repository metadata from the legacy unauthenticated `git://` transport to `git+https://`.

This is metadata-only: no runtime code, dependency, version, entrypoint, or package content changes.

Validation:
- Parsed `package.json` and confirmed `repository.url === "git+https://github.com/gruntjs/grunt-legacy-log-utils.git"`
- Verified the fork raw `package.json` contains the updated repository URL